### PR TITLE
Modified to `deferred` properly.

### DIFF
--- a/lib/niconico/deferrable.rb
+++ b/lib/niconico/deferrable.rb
@@ -5,7 +5,7 @@ class Niconico
         keys.each do |key|
           binding.eval(<<-EOM, __FILE__, __LINE__.succ)
             define_method(:#{key}) do
-              get() unless fetched?
+              get() if @#{key}.nil? && !fetched?
               @#{key}
             end
           EOM


### PR DESCRIPTION
I have improved the behavior of `Deferred` module.

Currently, it is NOT possible to get a list of id from the mylist.

```
nico.mylist(XXX).each do |video|
  p video # => #<Niconico::Video: sm9. "" (defered)>
  p video.id # => "sm9"
  p video # => #<Niconico::Video: sm9.flv "新・豪血寺一族 -煩悩解放 - レッツゴー！陰陽師"> #?!
  break
end

nico.mylist(YYY).map(&:id) # => raise Net::HTTPServiceUnavailable (503 error)
```

This is unexpected behavior. Request should be delayed.
