### PR TITLE
support comment download

### DIFF
--- a/lib/niconico.rb
+++ b/lib/niconico.rb
@@ -44,6 +44,14 @@ class Niconico
         )
       )
     end
+
+    # niconico comment server ignore 'Accept-Encoding' and return response by 'identity'
+    @agent.content_encoding_hooks << lambda do |a, uri, resp, body_io|
+      if resp['Content-Encoding'].to_s == 'identity'
+        resp['Content-Encoding'] = nil
+      end
+    end
+    @agent
   end
 
   def login(force=false)

--- a/lib/niconico.rb
+++ b/lib/niconico.rb
@@ -43,15 +43,14 @@ class Niconico
           name: 'lang', value: 'ja-jp',
         )
       )
-    end
 
-    # niconico comment server ignore 'Accept-Encoding' and return response by 'identity'
-    @agent.content_encoding_hooks << lambda do |a, uri, resp, body_io|
-      if resp['Content-Encoding'].to_s == 'identity'
-        resp['Content-Encoding'] = nil
+      # niconico comment server ignore 'Accept-Encoding' and return response by 'identity'
+      agent.content_encoding_hooks << lambda do |a, uri, resp, body_io|
+        if resp['Content-Encoding'].to_s == 'identity'
+          resp['Content-Encoding'] = nil
+        end
       end
     end
-    @agent
   end
 
   def login(force=false)

--- a/lib/niconico/video.rb
+++ b/lib/niconico/video.rb
@@ -109,15 +109,15 @@ class Niconico
       raise CommentUnavailableError unless @ms
 
       params = {}
-      params[:version] = 20090904
-      params[:res_from] = -1 * num
-      params[:thread] = @getflv_thread_id
-      params[:fork] = 1 if owner
+      params[:version] = '20090904'
+      params[:res_from] = (-1 * num).to_s
+      params[:thread] = @getflv_thread_id.to_s
+      params[:fork] = '1' if owner
 
       begin
         res = @agent.get(URI.join(@ms, "thread"), params)
       rescue Mechanize::ResponseCodeError => e
-        raise NotFound, "#{@id} not found" if e.message == "404 => Net::HTTPNotFound"
+        raise NotFound, "#{@id} comment not found" if e.response_code == "404"
         raise e
       end
       res.body

--- a/lib/niconico/video.rb
+++ b/lib/niconico/video.rb
@@ -115,7 +115,7 @@ class Niconico
       params[:fork] = 1 if owner
 
       begin
-        res = @agent.get(File.join(@ms, "thread"), params)
+        res = @agent.get(URI.join(@ms, "thread"), params)
       rescue Mechanize::ResponseCodeError => e
         raise NotFound, "#{@id} not found" if e.message == "404 => Net::HTTPNotFound"
         raise e


### PR DESCRIPTION
Support download comment xml.

Sometimes, comment server return raw text with 'identity' encoding.
This response raise error in this code.
https://github.com/sparklemotion/mechanize/blob/8d2e384a7b1b2c7d4538d453398ca877a711a1e3/lib/mechanize/http/agent.rb#L816

Even if we set accept-encoding, the server return 'identity' always.
The response is raw text, so I fixed content-encoding by nil.
